### PR TITLE
Add pages for privacy and terms of service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 # production
 /build
 
+/local
+
 # misc
 .DS_Store
 .env.local

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,15 +1,17 @@
 import React, { Component } from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 
+import Pages from "../pages/Pages";
 import Decks from "./decks/Decks";
 import Review from "./review/Review";
 import Collections from "./collections/Collections";
+import Logout from "./auth/Logout";
+import AuthRedirect from "./auth/AuthRedirect";
+
 import NotFound from "../components/NotFound";
 import GoogleAnalytics from "../components/GoogleAnalytics";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
-import Logout from "./auth/Logout";
-import AuthRedirect from "./auth/AuthRedirect";
 
 class App extends Component {
   render() {
@@ -24,6 +26,7 @@ class App extends Component {
                 <Route exact path="/" component={Decks} />
                 <Route path="/logout" component={Logout} />
                 <Route path="/auth/github" component={AuthRedirect} />
+                <Route path="/pages" component={Pages} />
                 <Route exact path="/categories/:categoryId" component={Decks} />
                 <Route exact path="/decks" component={Decks} />
                 <Route exact path="/decks/:deckId" component={Review} />

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,4 +1,6 @@
 import React from "react";
+import { Link } from "react-router-dom";
+
 import config from "../config";
 import * as analytics from "./GoogleAnalytics";
 
@@ -19,13 +21,34 @@ const Footer = () => (
           <small>
             <a
               href={config.buyMeACoffeeDonateUrl}
-              onClick={() => analytics.logDonateEvent2()}
               target="_blank"
               className="text-secondary"
               rel="noopener noreferrer"
             >
               Support Us
             </a>
+          </small>
+        </li>
+        <li className="list-inline-item">
+          <small>
+            <Link
+              onClick={() => analytics.logUserAction("Navigated to terms page")}
+              className="text-secondary"
+              to={"/pages/terms-of-service"}
+            >
+              Terms
+            </Link>
+          </small>
+        </li>
+        <li className="list-inline-item">
+          <small>
+            <Link
+              onClick={() => analytics.logUserAction("Navigated to privacy page")}
+              className="text-secondary"
+              to={"/pages/privacy-policy"}
+            >
+              Privacy
+            </Link>
           </small>
         </li>
         <li className="list-inline-item">

--- a/src/components/GoogleAnalytics.js
+++ b/src/components/GoogleAnalytics.js
@@ -109,6 +109,13 @@ export function logToggleFamiliarCards(isChecked) {
   });
 }
 
+export function logUserAction(action) {
+  ReactGA.event({
+    category: "Users",
+    action: action,
+  });
+}
+
 class GoogleAnalytics extends Component {
   componentWillMount() {
     const searchParams = queryString.parse(this.props.location.search);

--- a/src/index.css
+++ b/src/index.css
@@ -181,7 +181,7 @@ a[disabled] {
   height: 10px;
 }
 
-@media only screen and (max-width: 480px) {
+@media (max-width: 480px) {
   .navbar {
     margin-top: 50px;
   }

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+const About = () => (
+  <div className="container container--narrow py-5">
+    <h2>About</h2>
+  </div>
+);
+
+export default About;

--- a/src/pages/Pages.css
+++ b/src/pages/Pages.css
@@ -1,0 +1,15 @@
+.pages .container--narrow {
+  max-width: 830px;
+}
+
+.pages h2 {
+  font-size: 1.5em;
+  margin-bottom: 0.9em;
+}
+
+.pages p {
+  font-size: 1.15em;
+  line-height: 1.5em;
+  margin-bottom: 1.5em;
+  color: #818182;
+}

--- a/src/pages/Pages.css
+++ b/src/pages/Pages.css
@@ -1,15 +1,46 @@
+.pages h2 {
+  font-size: 1.5em;
+  margin-bottom: 1em;
+}
+
+.pages h3 {
+  font-size: 1.25em;
+  margin-bottom: 0.9em;
+}
+
+.pages p,
+.pages li {
+  font-weight: 300;
+  color: #868e96;
+}
+
+.pages p {
+  line-height: 1.5em;
+  margin-bottom: 1.5em;
+  overflow-x: hidden;
+}
+
 .pages .container--narrow {
   max-width: 830px;
 }
 
-.pages h2 {
-  font-size: 1.5em;
-  margin-bottom: 0.9em;
+.pages .pages-header {
+  align-items: center;
+  background: linear-gradient(0, #1d74f3, #3183f9);
+  height: 50px;
+  display: flex;
+  justify-content: center;
 }
 
-.pages p {
-  font-size: 1.15em;
-  line-height: 1.5em;
-  margin-bottom: 1.5em;
-  color: #818182;
+.pages .pages-hero {
+  font-size: 24px;
+}
+
+@media (min-width: 576px) {
+  .pages .pages-header {
+    height: 100px;
+  }
+  .pages .pages-hero {
+    font-size: 40px;
+  }
 }

--- a/src/pages/Pages.js
+++ b/src/pages/Pages.js
@@ -1,17 +1,20 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 
+import About from "./About";
 import PrivacyPolicy from "./PrivacyPolicy";
+import TermsOfService from "./TermsOfService";
 import NotFound from "../components/NotFound";
 
 import "./Pages.css";
 
-const About = () => <h1>About</h1>;
-
-const TermsOfService = () => <h1>Terms of Service</h1>;
-
 const Pages = () => (
   <div className="pages">
+    <div className="pages-header">
+      <span className="pages-hero" role="img" aria-label="Tada!">
+        🎉
+      </span>
+    </div>
     <Switch>
       <Route path="/pages/about" component={About} />
       <Route path="/pages/privacy-policy" component={PrivacyPolicy} />

--- a/src/pages/Pages.js
+++ b/src/pages/Pages.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+
+import PrivacyPolicy from "./PrivacyPolicy";
+import NotFound from "../components/NotFound";
+
+import "./Pages.css";
+
+const About = () => <h1>About</h1>;
+
+const TermsOfService = () => <h1>Terms of Service</h1>;
+
+const Pages = () => (
+  <div className="pages">
+    <Switch>
+      <Route path="/pages/about" component={About} />
+      <Route path="/pages/privacy-policy" component={PrivacyPolicy} />
+      <Route path="/pages/terms-of-service" component={TermsOfService} />
+      <Route exact path="*" component={NotFound} />
+    </Switch>
+  </div>
+);
+
+export default Pages;

--- a/src/pages/PrivacyPolicy.js
+++ b/src/pages/PrivacyPolicy.js
@@ -1,0 +1,44 @@
+import React from "react";
+
+const PrivacyPolicy = () => (
+  <div className="container container--narrow py-4">
+    <h2>Privacy Policy</h2>
+    <p>
+      Your privacy is important to us. It is Flashcards for Developers' policy to respect your
+      privacy regarding any information we may collect from you across our website,
+      http://www.flashcardsfordevelopers.com/, and other sites we own and operate.
+    </p>
+    <p>
+      We only ask for personal information when we truly need it to provide a service to you. We
+      collect it by fair and lawful means, with your knowledge and consent. We also let you know why
+      we’re collecting it and how it will be used.
+    </p>
+    <p>
+      We only retain collected information for as long as necessary to provide you with your
+      requested service. What data we store, we’ll protect within commercially acceptable means to
+      prevent loss and theft, as well as unauthorised access, disclosure, copying, use or
+      modification.
+    </p>
+    <p>
+      We don’t share any personally identifying information publicly or with third-parties, except
+      when required to by law.
+    </p>
+    <p>
+      Our website may link to external sites that are not operated by us. Please be aware that we
+      have no control over the content and practices of these sites, and cannot accept
+      responsibility or liability for their respective privacy policies.
+    </p>
+    <p>
+      You are free to refuse our request for your personal information, with the understanding that
+      we may be unable to provide you with some of your desired services.
+    </p>
+    <p>
+      Your continued use of our website will be regarded as acceptance of our practices around
+      privacy and personal information. If you have any questions about how we handle user data and
+      personal information, feel free to contact us.
+    </p>
+    <p>This policy is effective as of 8 September 2018.</p>
+  </div>
+);
+
+export default PrivacyPolicy;

--- a/src/pages/PrivacyPolicy.js
+++ b/src/pages/PrivacyPolicy.js
@@ -1,12 +1,13 @@
 import React from "react";
 
 const PrivacyPolicy = () => (
-  <div className="container container--narrow py-4">
+  <div className="container container--narrow py-5">
     <h2>Privacy Policy</h2>
     <p>
       Your privacy is important to us. It is Flashcards for Developers' policy to respect your
-      privacy regarding any information we may collect from you across our website,
-      http://www.flashcardsfordevelopers.com/, and other sites we own and operate.
+      privacy regarding any information we may collect from you across our website,{" "}
+      <a href="http://www.flashcardsfordevelopers.com">www.flashcardsfordevelopers.com</a>, and
+      other sites we own and operate.
     </p>
     <p>
       We only ask for personal information when we truly need it to provide a service to you. We
@@ -37,7 +38,7 @@ const PrivacyPolicy = () => (
       privacy and personal information. If you have any questions about how we handle user data and
       personal information, feel free to contact us.
     </p>
-    <p>This policy is effective as of 8 September 2018.</p>
+    <p>This policy is effective as of 1 September 2018.</p>
   </div>
 );
 

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -1,0 +1,101 @@
+import React from "react";
+
+const TermsOfService = () => (
+  <div className="container container--narrow py-5">
+    <h2>Terms of Service</h2>
+    <h3>1. Terms</h3>
+    <p>
+      By accessing the website at{" "}
+      <a href="http://www.flashcardsfordevelopers.com/">http://www.flashcardsfordevelopers.com/</a>,
+      you are agreeing to be bound by these terms of service, all applicable laws and regulations,
+      and agree that you are responsible for compliance with any applicable local laws. If you do
+      not agree with any of these terms, you are prohibited from using or accessing this site. The
+      materials contained in this website are protected by applicable copyright and trademark law.
+    </p>
+    <h3>2. Use License</h3>
+    <ol type="a">
+      <li>
+        Permission is granted to temporarily download one copy of the materials (information or
+        software) on Flashcards for Developers' website for personal, non-commercial transitory
+        viewing only. This is the grant of a license, not a transfer of title, and under this
+        license you may not:
+        <ol type="i">
+          <li>modify or copy the materials;</li>
+          <li>
+            use the materials for any commercial purpose, or for any public display (commercial or
+            non-commercial);
+          </li>
+          <li>
+            attempt to decompile or reverse engineer any software contained on Flashcards for
+            Developers' website;
+          </li>
+          <li>remove any copyright or other proprietary notations from the materials; or</li>
+          <li>
+            transfer the materials to another person or "mirror" the materials on any other server.
+          </li>
+        </ol>
+      </li>
+      <li>
+        This license shall automatically terminate if you violate any of these restrictions and may
+        be terminated by Flashcards for Developers at any time. Upon terminating your viewing of
+        these materials or upon the termination of this license, you must destroy any downloaded
+        materials in your possession whether in electronic or printed format.
+      </li>
+    </ol>
+    <h3>3. Disclaimer</h3>
+    <ol type="a">
+      <li>
+        The materials on Flashcards for Developers' website are provided on an 'as is' basis.
+        Flashcards for Developers makes no warranties, expressed or implied, and hereby disclaims
+        and negates all other warranties including, without limitation, implied warranties or
+        conditions of merchantability, fitness for a particular purpose, or non-infringement of
+        intellectual property or other violation of rights.
+      </li>
+      <li>
+        Further, Flashcards for Developers does not warrant or make any representations concerning
+        the accuracy, likely results, or reliability of the use of the materials on its website or
+        otherwise relating to such materials or on any sites linked to this site.
+      </li>
+    </ol>
+    <h3>4. Limitations</h3>
+    <p>
+      In no event shall Flashcards for Developers or its suppliers be liable for any damages
+      (including, without limitation, damages for loss of data or profit, or due to business
+      interruption) arising out of the use or inability to use the materials on Flashcards for
+      Developers' website, even if Flashcards for Developers or a Flashcards for Developers
+      authorized representative has been notified orally or in writing of the possibility of such
+      damage. Because some jurisdictions do not allow limitations on implied warranties, or
+      limitations of liability for consequential or incidental damages, these limitations may not
+      apply to you.
+    </p>
+    <h3>5. Accuracy of materials</h3>
+    <p>
+      The materials appearing on Flashcards for Developers' website could include technical,
+      typographical, or photographic errors. Flashcards for Developers does not warrant that any of
+      the materials on its website are accurate, complete or current. Flashcards for Developers may
+      make changes to the materials contained on its website at any time without notice. However
+      Flashcards for Developers does not make any commitment to update the materials.
+    </p>
+    <h3>6. Links</h3>
+    <p>
+      Flashcards for Developers has not reviewed all of the sites linked to its website and is not
+      responsible for the contents of any such linked site. The inclusion of any link does not imply
+      endorsement by Flashcards for Developers of the site. Use of any such linked website is at the
+      user's own risk.
+    </p>
+    <h3>7. Modifications</h3>
+    <p>
+      Flashcards for Developers may revise these terms of service for its website at any time
+      without notice. By using this website you are agreeing to be bound by the then current version
+      of these terms of service.
+    </p>
+    <h3>8. Governing Law</h3>
+    <p>
+      These terms and conditions are governed by and construed in accordance with the laws of New
+      York and you irrevocably submit to the exclusive jurisdiction of the courts in that State or
+      location.
+    </p>
+  </div>
+);
+
+export default TermsOfService;

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -6,11 +6,11 @@ const TermsOfService = () => (
     <h3>1. Terms</h3>
     <p>
       By accessing the website at{" "}
-      <a href="http://www.flashcardsfordevelopers.com/">http://www.flashcardsfordevelopers.com/</a>,
-      you are agreeing to be bound by these terms of service, all applicable laws and regulations,
-      and agree that you are responsible for compliance with any applicable local laws. If you do
-      not agree with any of these terms, you are prohibited from using or accessing this site. The
-      materials contained in this website are protected by applicable copyright and trademark law.
+      <a href="http://www.flashcardsfordevelopers.com">www.flashcardsfordevelopers.com</a>, you are
+      agreeing to be bound by these terms of service, all applicable laws and regulations, and agree
+      that you are responsible for compliance with any applicable local laws. If you do not agree
+      with any of these terms, you are prohibited from using or accessing this site. The materials
+      contained in this website are protected by applicable copyright and trademark law.
     </p>
     <h3>2. Use License</h3>
     <ol type="a">


### PR DESCRIPTION
### Description
This PR adds a `/pages` folder to contain a set of pages like the About page, Privacy, and Terms. It also adds some color to make @NickEngmann happy.

### Screenshots
![screen shot 2018-09-08 at 7 11 53 pm](https://user-images.githubusercontent.com/2153230/45259441-1812fb00-b39b-11e8-87a8-0d43b9299372.png)
