### PR TITLE
Enhance/mixpanel

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cookie-parser": "^1.4.3",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
+    "eslint": "^5.6.0",
     "eslint-config-prettier": "^3.0.1",
     "express": "^4.16.3",
     "forcedomain": "^1.0.0",
@@ -23,6 +24,7 @@
     "js-cookie": "^2.2.0",
     "jsonwebtoken": "^8.3.0",
     "marked": "^0.4.0",
+    "mixpanel-browser": "^2.22.4",
     "moment": "^2.22.2",
     "mongoose": "^5.2.10",
     "morgan": "^1.9.0",
@@ -57,5 +59,8 @@
   "devDependencies": {
     "eslint-plugin-prettier": "^2.6.2",
     "prettier": "^1.14.2"
+  },
+  "peerDependencies": {
+    "prop-types": "^15.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^16.4.1",
     "react-ga": "^2.5.3",
     "react-jss": "^8.5.1",
+    "react-mixpanel": "^0.0.11",
     "react-modal": "^3.5.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.4",

--- a/src/app/__tests__/CollectionsHome.test.js
+++ b/src/app/__tests__/CollectionsHome.test.js
@@ -7,6 +7,7 @@ jest.mock("../apiActions", () => ({
 }));
 
 it("renders without crashing", () => {
-  const wrapper = shallow(<CollectionsHome />);
+  const context = { mixpanel: { track: () => {} } };
+  const wrapper = shallow(<CollectionsHome />, { context });
   expect(wrapper).toHaveLength(1);
 });

--- a/src/app/__tests__/Home.test.js
+++ b/src/app/__tests__/Home.test.js
@@ -10,6 +10,7 @@ jest.mock("../apiActions", () => ({
 }));
 
 it("renders without crashing", () => {
-  const wrapper = shallow(<Home />);
+  const context = { mixpanel: { track: () => {} } };
+  const wrapper = shallow(<Home />, { context });
   expect(wrapper).toHaveLength(1);
 });

--- a/src/app/__tests__/Review.test.js
+++ b/src/app/__tests__/Review.test.js
@@ -3,6 +3,7 @@ import { shallow } from "enzyme";
 import Review from "../review/Review";
 
 it("renders without crashing", () => {
-  const wrapper = shallow(<Review />);
+  const context = { mixpanel: { track: () => {} } };
+  const wrapper = shallow(<Review />, { context });
   expect(wrapper).toHaveLength(1);
 });

--- a/src/app/auth/SignupFormModal.js
+++ b/src/app/auth/SignupFormModal.js
@@ -21,7 +21,6 @@ class SignupFormModal extends Component {
   };
 
   componentDidMount() {
-    this.context.mixpanel.track('SignUp Form Modal.');
     this.setState({ profile: { ...this.props.profile } });
   }
 

--- a/src/app/auth/SignupFormModal.js
+++ b/src/app/auth/SignupFormModal.js
@@ -21,6 +21,7 @@ class SignupFormModal extends Component {
   };
 
   componentDidMount() {
+    this.context.mixpanel.track('SignUp Form Modal.');
     this.setState({ profile: { ...this.props.profile } });
   }
 

--- a/src/app/collections/CollectionsHome.js
+++ b/src/app/collections/CollectionsHome.js
@@ -1,5 +1,5 @@
 import React from "react";
-
+import PropTypes from 'prop-types';
 import * as api from "../apiActions";
 import CollectionItem from "./CollectionItem";
 
@@ -34,4 +34,8 @@ class CollectionsHome extends React.Component {
     );
   }
 }
+
+CollectionsHome.contextTypes = {
+  mixpanel: PropTypes.object.isRequired
+};
 export default CollectionsHome;

--- a/src/app/collections/CollectionsHome.js
+++ b/src/app/collections/CollectionsHome.js
@@ -7,6 +7,7 @@ class CollectionsHome extends React.Component {
   state = { collections: [] };
 
   componentDidMount() {
+    this.context.mixpanel.track('Collections Page.');
     this.fetchCollections();
   }
 

--- a/src/app/home/Home.js
+++ b/src/app/home/Home.js
@@ -7,6 +7,7 @@ import * as api from "../apiActions";
 import * as analytics from "../../components/GoogleAnalytics";
 import * as localStorage from "../utils/localStorage";
 
+import PropTypes from 'prop-types';
 import CollectionItem from "../collections/CollectionItem";
 import HabitTracker from "./HabitTracker";
 import FeedbackForm from "./FeedbackForm";
@@ -28,7 +29,7 @@ class Decks extends Component {
 
   componentWillMount() {
     document.title = "Flashcards for Developers";
-
+    this.context.mixpanel.track('Home page.');
     this.fetchPinnedDecks();
 
     this.fetchFeaturedCollection();
@@ -333,4 +334,7 @@ class Decks extends Component {
   }
 }
 
+Decks.contextTypes = {
+  mixpanel: PropTypes.object.isRequired
+};
 export default Decks;

--- a/src/app/review/Review.js
+++ b/src/app/review/Review.js
@@ -71,7 +71,7 @@ class Review extends Component {
 
   componentDidMount() {
     const { params } = this.props.match;
-
+    this.context.mixpanel.track('Review Page.');
     if (this.isCollectionPage()) {
       this.fetchCollection(params.collectionId);
       this.fetchMixedCards(params.collectionId);

--- a/src/app/review/Review.js
+++ b/src/app/review/Review.js
@@ -3,7 +3,7 @@ import cx from "classnames";
 import marked from "marked";
 import Chance from "chance";
 import moment from "moment";
-
+import PropTypes from 'prop-types';
 import config from "../../config";
 import isAuthenticated from "../utils/isAuthenticated";
 import * as leitner from "../../spaced/leitner";
@@ -173,7 +173,7 @@ class Review extends Component {
 
     const isCorrect = answer === SELF_GRADE_CORRECT;
     const card = this.getCurrentCard();
-
+    this.context.mixpanel.track('Reviews Card.');
     analytics.logReviewEvent(card.id);
     this.setStudyProgress(card, isCorrect);
 
@@ -198,6 +198,7 @@ class Review extends Component {
 
     if (isCorrect) {
       this.setState({ correctness: [...this.state.correctness, isCorrect] });
+      this.context.mixpanel.track('Reviews Card.');
       analytics.logReviewEvent(card.id);
       this.timeout = setTimeout(() => this.handleCorrectAnswer(), 300);
     } else {
@@ -233,8 +234,10 @@ class Review extends Component {
 
   logReviewEvent = index => {
     if (this.isDeckCompleted(index)) {
+      this.context.mixpanel.track('Complete Event Log.');
       analytics.logCompletedEvent(this.state.deck.id);
     } else {
+      this.context.mixpanel.track('Finish Deck.');
       analytics.logFinishedEvent(this.state.deck.id);
     }
   };
@@ -602,4 +605,7 @@ Review.defaultProps = {
   match: { params: {} },
 };
 
+Review.contextTypes = {
+  mixpanel: PropTypes.object.isRequired
+};
 export default Review;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,10 +3,10 @@ export default {
   airtableFeedbackUrl: process.env.REACT_APP_AIRTABLE_FEEDBACK_URL || "",
   airtableSuggestionsUrl: process.env.REACT_APP_AIRTABLE_SUGGESTIONS_URL || "",
   airtableEmailUrl: process.env.REACT_APP_AIRTABLE_EMAIL_URL || "",
+  mixpanelAnalyticsKey: process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY || "",
   googleAnalyticsKey: process.env.REACT_APP_GOOGLE_ANALYTICS_KEY || "",
   mailchimpUrl: process.env.REACT_APP_AIRTABLE_MAILCHIMP_URL || "",
   buyMeACoffeeDonateUrl: process.env.REACT_APP_DONATE_URL || "",
   githubOAuthClientId: process.env.REACT_APP_GITHUB_OAUTH_CLIENT_ID || "",
   githubOAuthRedirectURI: process.env.REACT_APP_GITHUB_OAUTH_REDIRECT_URI || "",
-  mixpanelAnalyticsKey: process.env.MIXPANEL_ANALYTICS_KEY || "",
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -8,4 +8,5 @@ export default {
   buyMeACoffeeDonateUrl: process.env.REACT_APP_DONATE_URL || "",
   githubOAuthClientId: process.env.REACT_APP_GITHUB_OAUTH_CLIENT_ID || "",
   githubOAuthRedirectURI: process.env.REACT_APP_GITHUB_OAUTH_REDIRECT_URI || "",
+  mixpanelAnalyticsKey: process.env.MIXPANEL_ANALYTICS_KEY || "",
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,4 @@
-export default {
+const configs = {
   airtableReportUrl: process.env.REACT_APP_AIRTABLE_REPORT_URL || "",
   airtableFeedbackUrl: process.env.REACT_APP_AIRTABLE_FEEDBACK_URL || "",
   airtableSuggestionsUrl: process.env.REACT_APP_AIRTABLE_SUGGESTIONS_URL || "",
@@ -10,3 +10,5 @@ export default {
   githubOAuthClientId: process.env.REACT_APP_GITHUB_OAUTH_CLIENT_ID || "",
   githubOAuthRedirectURI: process.env.REACT_APP_GITHUB_OAUTH_REDIRECT_URI || "",
 };
+
+export default configs;

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ import ReactDOM from "react-dom";
 import App from "./app/App";
 import { unregister } from "./registerServiceWorker";
 import config from "./config";
-import mixpanel from 'mixpanel-browser';
-import MixpanelProvider from 'react-mixpanel';
+import mixpanel from "mixpanel-browser";
+import MixpanelProvider from "react-mixpanel";
 
 import "primer-markdown/build/build.css";
 import "rc-tooltip/assets/bootstrap.css";

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,10 @@ import "./index.css";
 
 mixpanel.init(config.mixpanelAnalyticsKey);
 
-ReactDOM.render(    
-    <MixpanelProvider mixpanel={mixpanel}>
-        <App/>
-    </MixpanelProvider>,
-    document.getElementById("root")
+ReactDOM.render(
+  <MixpanelProvider mixpanel={mixpanel}>
+    <App />
+  </MixpanelProvider>,
+  document.getElementById("root"),
 );
 unregister();

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,21 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./app/App";
 import { unregister } from "./registerServiceWorker";
+import config from "./config";
+import mixpanel from 'mixpanel-browser';
+import MixpanelProvider from 'react-mixpanel';
 
 import "primer-markdown/build/build.css";
 import "rc-tooltip/assets/bootstrap.css";
 
 import "./index.css";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+mixpanel.init(config.mixpanelAnalyticsKey);
+
+ReactDOM.render(    
+    <MixpanelProvider mixpanel={mixpanel}>
+        <App/>
+    </MixpanelProvider>,
+    document.getElementById("root")
+);
 unregister();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6517,6 +6517,10 @@ react-lifecycles-compat@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
+react-mixpanel@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/react-mixpanel/-/react-mixpanel-0.0.11.tgz#4f535426fd6ff7de58a133543d6df569a55ab06e"
+
 react-modal@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.5.1.tgz#33d38527def90ea324848f7d63e53acc4468a451"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,20 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
 "@types/node@*":
   version "10.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.10.1.tgz#d5c96ca246a418404914d180b7fdd625ad18eca6"
@@ -39,6 +53,12 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
+  dependencies:
+    acorn "^5.0.3"
+
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
@@ -50,6 +70,10 @@ acorn@^4.0.3, acorn@^4.0.4:
 acorn@^5.0.0, acorn@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
+acorn@^5.0.3, acorn@^5.6.0:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
 add-dom-event-listener@1.x:
   version "1.0.2"
@@ -95,6 +119,15 @@ ajv@^6.0.1:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.1"
+
+ajv@^6.5.3:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1445,6 +1478,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -1839,6 +1876,16 @@ cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -2242,7 +2289,7 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0:
+doctrine@^2.0.0, doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -2657,6 +2704,21 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
 eslint@4.10.0:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.10.0.tgz#f25d0d7955c81968c2309aa5c9a229e045176bb7"
@@ -2699,12 +2761,62 @@ eslint@4.10.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
+eslint@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.6.0.tgz#b6f7806041af01f71b3f1895cbb20971ea4b6223"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.5.3"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    imurmurhash "^0.1.4"
+    inquirer "^6.1.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
+
 espree@^3.5.1:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
+
+espree@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
+  dependencies:
+    acorn "^5.6.0"
+    acorn-jsx "^4.1.1"
 
 esprima@^2.6.0:
   version "2.7.3"
@@ -2718,7 +2830,7 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
-esquery@^1.0.0:
+esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
@@ -2896,6 +3008,14 @@ external-editor@^2.0.4:
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
 extglob@^0.3.1:
@@ -3326,6 +3446,10 @@ global@~4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
+globals@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -3674,6 +3798,12 @@ iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -3701,6 +3831,10 @@ ignore-walk@^3.0.1:
 ignore@^3.3.3:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -3765,6 +3899,24 @@ inquirer@3.3.0, inquirer@^3.0.6:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -4046,7 +4198,7 @@ is-regex@^1.0.4:
   dependencies:
     has "^1.0.1"
 
-is-resolvable@^1.0.0:
+is-resolvable@^1.0.0, is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
@@ -4448,7 +4600,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.1:
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
+js-yaml@^3.12.0, js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -4513,6 +4669,10 @@ json-schema-traverse@^0.4.1:
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -4901,6 +5061,10 @@ lodash@4.17.10, "lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
+lodash@^4.17.5:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
 loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
@@ -5157,6 +5321,10 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mixpanel-browser@^2.22.4:
+  version "2.22.4"
+  resolved "https://registry.yarnpkg.com/mixpanel-browser/-/mixpanel-browser-2.22.4.tgz#f1d57a2c2f50801f57357fb16f38288bcee3cc7d"
+
 mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -5311,6 +5479,10 @@ neo-async@^2.5.0:
 next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -5794,7 +5966,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -6788,6 +6960,10 @@ regexp-clone@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-0.0.1.tgz#a7c2e09891fdbf38fbb10d376fb73003e68ac589"
 
+regexpp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.0.tgz#b2a7534a85ca1b033bcf5ce9ff8e56d4e0755365"
+
 regexpu-core@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
@@ -7043,6 +7219,12 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
+rxjs@^6.1.0:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -7113,7 +7295,7 @@ semver-diff@^2.0.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-semver@^5.5.0:
+semver@^5.5.0, semver@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
@@ -7540,7 +7722,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -7651,7 +7833,7 @@ symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^4.0.1:
+table@^4.0.1, table@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
   dependencies:
@@ -7694,7 +7876,7 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-table@0.2.0, text-table@~0.2.0:
+text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -7817,6 +7999,10 @@ trim-right@^1.0.1:
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -7963,7 +8149,7 @@ upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
-uri-js@^4.2.1:
+uri-js@^4.2.1, uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:


### PR DESCRIPTION
Simple Mixpanel addition using [React-Mixpanel](https://github.com/neciu/react-mixpanel).
Only tracking a handful of events such as reviewing cards, completing decks, visiting the home page and viewing collections. Mainly see the practicality in tracking User Retention easily using Mixpanel, tracking funnels (how many cards a user reviews before they leave, and which decks are people leaving from often), and how the collections page influences users choices of decks to view.

![image](https://user-images.githubusercontent.com/1075072/46062414-93f09f80-c11e-11e8-95cf-11967846db3a.png)
