### PR TITLE
Fixes for missing Stripe and Mixpanel tokens (Fixes #99)

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -3,6 +3,12 @@ const config = require("../config/index");
 
 module.exports = () => {
   mongoose.Promise = global.Promise;
+
+  if (!config.database.uri) {
+  	console.warn("DATABASE_URI environment variable not set.\nPlease set DATABASE_URI environment variable to run flashcards-for-developers");
+  	process.exit();
+  }
+
   mongoose.connect(
     config.database.uri,
     { useNewUrlParser: true },

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,13 +3,13 @@ const configs = {
   airtableFeedbackUrl: process.env.REACT_APP_AIRTABLE_FEEDBACK_URL || "",
   airtableSuggestionsUrl: process.env.REACT_APP_AIRTABLE_SUGGESTIONS_URL || "",
   airtableEmailUrl: process.env.REACT_APP_AIRTABLE_EMAIL_URL || "",
-  mixpanelAnalyticsKey: process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY || "",
+  mixpanelAnalyticsKey: process.env.REACT_APP_MIXPANEL_ANALYTICS_KEY || "DUMMY_MIXPANEL_TOKEN",
   googleAnalyticsKey: process.env.REACT_APP_GOOGLE_ANALYTICS_KEY || "",
   mailchimpUrl: process.env.REACT_APP_AIRTABLE_MAILCHIMP_URL || "",
   buyMeACoffeeDonateUrl: process.env.REACT_APP_DONATE_URL || "",
   githubOAuthClientId: process.env.REACT_APP_GITHUB_OAUTH_CLIENT_ID || "",
   githubOAuthRedirectURI: process.env.REACT_APP_GITHUB_OAUTH_REDIRECT_URI || "",
-  stripePublicKey: process.env.REACT_APP_STRIPE_PUBLIC_KEY || "",
+  stripePublicKey: process.env.REACT_APP_STRIPE_PUBLIC_KEY || "tok_visa", // Fallback to dummy stripe token
 };
 
 export default configs;

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,11 @@ import "./index.css";
 
 mixpanel.init(config.mixpanelAnalyticsKey);
 
+if (config.mixpanelAnalyticsKey === "DUMMY_MIXPANEL_TOKEN") {
+	// Disable Mixpanel event tracking if dummy token is provided
+	mixpanel.disable();
+}
+
 ReactDOM.render(
   <StripeProvider apiKey={config.stripePublicKey}>
     <MixpanelProvider mixpanel={mixpanel}>


### PR DESCRIPTION
In reference to issue #97, when the Stripe token is missing, or the Mixpanel token is missing, the web application fails to load and errors out. I've used dummy tokens to fix this issue. 

For Stripe, they provide dummy tokens on their site, see https://stripe.com/docs/testing#cards
Using a random non 0 length string for Mixpanel seems to do the trick, and I disable Mixpanel event tracking in case the dummy token is being used. 